### PR TITLE
Embed 2025 catalog PDF on homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -51,34 +51,63 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 				text-align: center;
 				transition: background-color 0.3s ease;
 			}
-			.button:hover {
-				background-color: #168a14;
-			}
+                        .button:hover {
+                                background-color: #168a14;
+                        }
 
-			/* Responsive typography */
-			h1 {
-				font-size: 1.8rem;
-			}
+                        .floating-buttons {
+                                position: fixed;
+                                bottom: 0;
+                                left: 0;
+                                width: 100%;
+                                display: flex;
+                                gap: 0.5rem;
+                                padding: 0.5rem;
+                                background: rgba(255, 255, 255, 0.95);
+                                box-shadow: 0 -2px 4px rgba(0, 0, 0, 0.1);
+                                z-index: 1000;
+                        }
+                        .floating-buttons .button {
+                                flex: 1;
+                                margin-top: 0;
+                        }
+
+                        @media (max-width: 767px) {
+                                body {
+                                        padding-bottom: 4rem;
+                                }
+                                .cta-desktop {
+                                        display: none;
+                                }
+                        }
+
+                        /* Responsive typography */
+                        h1 {
+                                font-size: 1.8rem;
+                        }
 			h2 {
 				font-size: 1.4rem;
 			}
 
-			/* Responsiveness */
-			@media (min-width: 768px) {
-				main {
-					max-width: 80ch;
-				}
-				h1 {
-					font-size: 2.2rem;
-				}
-				h2 {
-					font-size: 1.6rem;
-				}
-			}
-		</style>
-	</head>
-	<body>
-		<Header />
+                        /* Responsiveness */
+                        @media (min-width: 768px) {
+                                main {
+                                        max-width: 80ch;
+                                }
+                                h1 {
+                                        font-size: 2.2rem;
+                                }
+                                h2 {
+                                        font-size: 1.6rem;
+                                }
+                                .floating-buttons {
+                                        display: none;
+                                }
+                        }
+                </style>
+        </head>
+        <body>
+                <Header />
 		<main>
 			<h1>Selamat Datang di Alkes Duaputry</h1>
 			<p>
@@ -90,17 +119,19 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 			
 			<h2>Produk Unggulan Kami</h2>
 			<p>Kami menyediakan berbagai macam alat kesehatan, termasuk:</p>
-			<ul>
-				<li>Tempat Tidur Pasien (berbagai jenis)</li>
-				<li>Peralatan Obgyn dan Kebidanan</li>
-				<li>Inkubator Bayi dan Perlengkapan Neonatal</li>
-				<li>Dan ratusan produk lainnya yang dapat Anda lihat di katalog kami.</li>
-			</ul>
-			<p>
-				<a href="https://alkesduaputry.com/wp-content/uploads/2024/03/KATALOG-ALKESDUAPUTRY-2024-BARU.pdf" class="button" target="_blank" rel="noopener noreferrer">
-					Download Katalog Terbaru 2024
-				</a>
-			</p>
+                        <ul>
+                                <li>Tempat Tidur Pasien (berbagai jenis)</li>
+                                <li>Peralatan Obgyn dan Kebidanan</li>
+                                <li>Inkubator Bayi dan Perlengkapan Neonatal</li>
+                                <li>Dan ratusan produk lainnya yang dapat Anda lihat di katalog kami.</li>
+                        </ul>
+                        <p>
+                                <a href="https://files.alkesduaputry.com/katalog-2025.pdf" class="button cta-desktop" target="_blank" rel="noopener noreferrer">
+                                        Download Katalog Terbaru 2025
+                                </a>
+                        </p>
+                        <h2>Katalog 2025</h2>
+                        <iframe src="https://files.alkesduaputry.com/katalog-2025.pdf" style="width:100%;height:600px;" title="Katalog 2025"></iframe>
 
 			<h2>Lokasi Kami</h2>
 			<p>
@@ -108,16 +139,20 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 				<br>
 				<strong>Tarikolot, Kec. Citeureup, Kabupaten Bogor, Jawa Barat 16811</strong>
 			</p>
-			<p>
-				Atau hubungi kami melalui WhatsApp untuk konsultasi gratis mengenai kebutuhan alat kesehatan Anda. Kami melayani 24 jam sehari, 7 hari seminggu.
-			</p>
-			<p>
-				<a href="https://wa.me/6285780199904?text=Salam%20saya%20ingin%20berkonsultasi%20mengenai%20Alat%20kesehatan%20yang%20di%20jual%20di%20alkesduaputry.com" 
-				   class="button">
-					Hubungi Kami di WhatsApp
-				</a>
-			</p>
-		</main>
-		<Footer />
-	</body>
+                        <p>
+                                Atau hubungi kami melalui WhatsApp untuk konsultasi gratis mengenai kebutuhan alat kesehatan Anda. Kami melayani 24 jam sehari, 7 hari seminggu.
+                        </p>
+                        <p>
+                                <a href="https://wa.me/6285780199904?text=Salam%20saya%20ingin%20berkonsultasi%20mengenai%20Alat%20kesehatan%20yang%20di%20jual%20di%20alkesduaputry.com"
+                                   class="button cta-desktop">
+                                        Hubungi Kami di WhatsApp
+                                </a>
+                        </p>
+                </main>
+                <Footer />
+                <div class="floating-buttons">
+                        <a href="https://files.alkesduaputry.com/katalog-2025.pdf" class="button" target="_blank" rel="noopener noreferrer">Download Katalog</a>
+                        <a href="https://wa.me/6285780199904?text=Salam%20saya%20ingin%20berkonsultasi%20mengenai%20Alat%20kesehatan%20yang%20di%20jual%20di%20alkesduaputry.com" class="button">Hubungi Kami</a>
+                </div>
+        </body>
 </html>


### PR DESCRIPTION
## Summary
- update homepage link to 2025 catalog PDF and embed inline viewer
- add floating mobile footer buttons for catalog download and WhatsApp contact

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a73b73fdd88326befc6c02bfbc1367